### PR TITLE
Pull request to add MMC command to send shutdown signal, change IMAGE_TYPE_ID_GUID, PcdSerialRegisterBase value, remove the CPM feature, fix for PCIe load default, update PCD variables for SMBIOS Type 0,1,2

### DIFF
--- a/Platform/Ampere/JadePkg/Capsule/SystemFirmwareDescriptor/SystemFirmwareDescriptor.aslc
+++ b/Platform/Ampere/JadePkg/Capsule/SystemFirmwareDescriptor/SystemFirmwareDescriptor.aslc
@@ -28,7 +28,7 @@
 #define IMAGE_ID_STRING                     L"Ampere Altra Developer Platform Firmware"
 //><ADLINK-MS20233010>//
 // PcdSystemFmpCapsuleImageTypeIdGuid
-#define IMAGE_TYPE_ID_GUID                  { 0xf08bca31, 0x542e, 0x4cea, { 0x8b, 0x48, 0x8e, 0x54, 0xf9, 0x42, 0x25, 0x94 } }
+#define IMAGE_TYPE_ID_GUID                  { 0xcdcdd0b7, 0x8afb, 0x4883, { 0x85, 0x3a, 0xae, 0x93, 0x98, 0x07, 0x7a, 0x0e } }
 
 typedef struct {
   EDKII_SYSTEM_FIRMWARE_IMAGE_DESCRIPTOR  Descriptor;

--- a/Silicon/Ampere/AmpereAltraPkg/AmpereAltraPkg.dsc.inc
+++ b/Silicon/Ampere/AmpereAltraPkg/AmpereAltraPkg.dsc.inc
@@ -441,8 +441,10 @@
   #
   # PL011 - Serial Terminal
   # Ampere Altra UART0
-  #
-  gEfiMdeModulePkgTokenSpaceGuid.PcdSerialRegisterBase|0x100002600000
+  # 
+  # //><ADLINK-MS20240103>//
+  gEfiMdeModulePkgTokenSpaceGuid.PcdSerialRegisterBase|0x100002630000
+  # //><ADLINK-MS20240103>//
   gEfiMdePkgTokenSpaceGuid.PcdUartDefaultBaudRate|115200
   gEfiMdePkgTokenSpaceGuid.PcdUartDefaultReceiveFifoDepth|32
   gEfiMdePkgTokenSpaceGuid.PcdUartDefaultDataBits|8

--- a/Silicon/Ampere/AmpereAltraPkg/AmpereAltraPkg.dsc.inc
+++ b/Silicon/Ampere/AmpereAltraPkg/AmpereAltraPkg.dsc.inc
@@ -541,8 +541,15 @@
   # SMBIOS PCDs
   #
   gArmTokenSpaceGuid.PcdProcessorManufacturer|L"Ampere(R)"
-  gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwareVendor|L"Ampere(R)"
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwareVendor|L"ADLINK"
   gArmTokenSpaceGuid.PcdProcessorAssetTag|L"Not Set"
+  
+  gArmTokenSpaceGuid.PcdSystemProductName|L"Ampere Altra Developer Platform"
+  gArmTokenSpaceGuid.PcdSystemVersion|L"A2"
+  
+  gArmTokenSpaceGuid.PcdBaseBoardManufacturer|L"ADLINK"
+  gArmTokenSpaceGuid.PcdBaseBoardProductName|L"Ampere Altra Developer Platform"
+  gArmTokenSpaceGuid.PcdBaseBoardVersion|L"A2"
 
 [PcdsDynamicHii.common.DEFAULT]
   gEfiMdePkgTokenSpaceGuid.PcdPlatformBootTimeOut|L"Timeout"|gEfiGlobalVariableGuid|0x0|10

--- a/Silicon/Ampere/AmpereAltraPkg/Drivers/BootProgress/BootProgressDxe/BootProgressDxe.c
+++ b/Silicon/Ampere/AmpereAltraPkg/Drivers/BootProgress/BootProgressDxe/BootProgressDxe.c
@@ -20,19 +20,24 @@
 #include <Library/UefiBootServicesTableLib.h>
 #include <Pi/PiStatusCode.h>
 #include <Protocol/ReportStatusCodeHandler.h>
+#include <Library/PcdLib.h>
+#include <Library/PL011UartClockLib.h>
+#include <Library/PL011UartLib.h>
+#include <Library/SerialPortLib.h>
+
+#define _PCD_GET_MODE_64_PcdSerialDbgRegisterBase 0x0000100002620000
 
 typedef struct {
   UINT8                 Byte;
   EFI_STATUS_CODE_VALUE Value;
 } STATUS_CODE_TO_CHECKPOINT;
 
-typedef enum {
-  BootNotStart = 0,
-  BootStart,
-  BootComplete,
-  BootFailed,
-  BootProgressStateMax
-} BOOT_PROGRESS_STATE;
+enum BOOT_PROGRESS_STATE {
+  BOOT_NOTSTART = 0,
+  BOOT_START    = 1,
+  BOOT_COMPLETE = 2,
+  BOOT_FAILED   = 3,
+};
 
 UINT32 DxeProgressCode[] = {
   (EFI_SOFTWARE_DXE_CORE | EFI_SW_DXE_CORE_PC_ENTRY_POINT),                     // DXE Core is started
@@ -83,7 +88,7 @@ UINT32 DxeErrorCode[] = {
 
 EFI_RSC_HANDLER_PROTOCOL *mRscHandlerProtocol = NULL;
 
-STATIC UINT8 mBootstate = BootStart;
+STATIC UINT8 mBootstate = BOOT_START;
 
 STATIC BOOLEAN mEndOfDxe = FALSE;
 
@@ -104,6 +109,28 @@ StatusCodeFilter (
   }
   return FALSE;
 }
+
+EFI_STATUS
+SendShutdownSignal (
+  VOID
+  )
+{
+  UINTN   numofbytes;
+  UINT8   IpmiCmdBuf[] = {"[C0 00 15 01]\r\n"};
+  UINTN   IpmiCmdBufSize;
+  IpmiCmdBufSize = sizeof(IpmiCmdBuf);
+
+  numofbytes = PL011UartWrite ((UINTN)PcdGet64 (PcdSerialDbgRegisterBase), IpmiCmdBuf, IpmiCmdBufSize);
+  DEBUG ((DEBUG_INFO, "%a numofbytes %d\n", __FUNCTION__,numofbytes));
+
+  if (numofbytes == 0) {
+    DEBUG ((DEBUG_ERROR, "%a Failed to Write data\n", __FUNCTION__));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  return EFI_SUCCESS;
+}
+
 
 /**
   Report status code listener of Boot Progress Dxe.
@@ -137,6 +164,7 @@ BootProgressListenerDxe (
   UINT8   BootStage;
   BOOLEAN IsProgress = FALSE;
   BOOLEAN IsError = FALSE;
+  EFI_STATUS status;
 
   if ((CodeType & EFI_STATUS_CODE_TYPE_MASK) == EFI_PROGRESS_CODE) {
     IsProgress= StatusCodeFilter (DxeProgressCode, Value);
@@ -161,14 +189,20 @@ BootProgressListenerDxe (
     ));
 
   if (IsError) {
-    mBootstate = BootFailed;
+    mBootstate = BOOT_FAILED;
   } else if ((Value == (EFI_SOFTWARE_EFI_BOOT_SERVICE | EFI_SW_BS_PC_EXIT_BOOT_SERVICES))
             || (Value == (EFI_SOFTWARE_DXE_CORE | EFI_SW_DXE_CORE_PC_HANDOFF_TO_NEXT)))
   {
     /* Set boot complete when reach to Exit Boot Service event or DXE Core Handoff To Next */
-    mBootstate = BootComplete;
+    mBootstate = BOOT_COMPLETE;
+
+    status = SendShutdownSignal ();
+    if (EFI_ERROR (status)) {
+      DEBUG ((DEBUG_ERROR, "%a Failed to SendShutdownSignal\n", __FUNCTION__));
+      return status;
+    }
   } else {
-    mBootstate = BootStart;
+    mBootstate = BOOT_START;
   }
 
   BootStage = mEndOfDxe ? MAILBOX_BOOT_PROGRESS_STAGE_OS : MAILBOX_BOOT_PROGRESS_STAGE_UEFI;

--- a/Silicon/Ampere/AmpereAltraPkg/Drivers/BootProgress/BootProgressDxe/BootProgressDxe.inf
+++ b/Silicon/Ampere/AmpereAltraPkg/Drivers/BootProgress/BootProgressDxe/BootProgressDxe.inf
@@ -31,6 +31,7 @@
 [Packages]
   MdeModulePkg/MdeModulePkg.dec
   MdePkg/MdePkg.dec
+  ArmPlatformPkg/ArmPlatformPkg.dec
   Silicon/Ampere/AmpereAltraPkg/AmpereAltraPkg.dec
 
 [LibraryClasses]
@@ -43,6 +44,7 @@
   UefiDriverEntryPoint
   UefiLib
   UefiRuntimeServicesTableLib
+  PL011UartLib
 
 [Protocols]
   gEfiRscHandlerProtocolGuid                    ## CONSUMES

--- a/Silicon/Ampere/AmpereAltraPkg/Drivers/CpuConfigDxe/CpuConfigDxe.c
+++ b/Silicon/Ampere/AmpereAltraPkg/Drivers/CpuConfigDxe/CpuConfigDxe.c
@@ -75,11 +75,15 @@ CpuNvParamGet (
 {
   EFI_STATUS Status;
   UINT32     Value;
-//><ADLINK-MS20233010>//
+  
+  
+//><ADLINK-MS20240403>//
+#if 0
   UINT32     CPMcount;
   UINT16     MaxCPM = 16;
   INTN       i;
-//><ADLINK-MS20233010>//
+#endif
+//><ADLINK-MS20240403>//
 
   ASSERT (Configuration != NULL);
 
@@ -95,7 +99,8 @@ CpuNvParamGet (
     Configuration->CpuSubNumaMode = Value;
   }
 
-//><ADLINK-MS20233010>//
+//><ADLINK-MS20240403>//
+#if 0
   CPMcount = GetNumberOfConfiguredCPMs(0);
 
   if (CPMcount == 0){
@@ -108,7 +113,8 @@ CpuNvParamGet (
       Configuration->CPMs[i] = 1;
     }
   }
-//><ADLINK-MS20233010>//
+#endif
+//><ADLINK-MS20240403>//
   return EFI_SUCCESS;
 }
 
@@ -120,11 +126,13 @@ CpuNvParamSet (
 {
   EFI_STATUS Status;
   UINT32     Value;
-//><ADLINK-MS20233010>//
+//><ADLINK-MS20240403>//
+#if 0
   UINT32     CPMcount = 0;
   UINT16     MaxCPM = 16;
   INTN       i;
-//><ADLINK-MS20233010>//
+ #endif
+//><ADLINK-MS20240403>//
 
   ASSERT (Configuration != NULL);
 
@@ -148,7 +156,8 @@ CpuNvParamSet (
       return Status;
     }
   }
-//><ADLINK-MS20233010>//
+//><ADLINK-MS20240403>//
+#if 0
   for (i=0; i<MaxCPM; i++){
     if (Configuration->CPMs[i] == 1){
       CPMcount++;
@@ -159,7 +168,8 @@ CpuNvParamSet (
   }
 
   SetNumberOfConfiguredCPMs(0, CPMcount);
-//><ADLINK-MS20233010>//
+#endif
+//><ADLINK-MS20240403>//
   return EFI_SUCCESS;
 }
 

--- a/Silicon/Ampere/AmpereAltraPkg/Drivers/CpuConfigDxe/CpuConfigVfr.vfr
+++ b/Silicon/Ampere/AmpereAltraPkg/Drivers/CpuConfigDxe/CpuConfigVfr.vfr
@@ -53,10 +53,12 @@ formset
       endoneof;
     endif;
  
-//><ADLINK-MS20233010>//
+//><ADLINK-MS20240403>//
+#if 0
     goto ACTIVE_CORE_FORM_ID,
       prompt = STRING_TOKEN(STR_ACTIVE_CORE_COUNT_CONFIG_PROMPT),
       help   = STRING_TOKEN(STR_ACTIVE_CORE_COUNT_CONFIG_PROMPT_HELP);
+
   endform;
 
   form formid = ACTIVE_CORE_FORM_ID,
@@ -344,7 +346,8 @@ formset
         option text = STRING_TOKEN(STR_CPU_CPM_DISABLED), value = 0x0, flags = DEFAULT;
       endoneof;
     endif;
-//><ADLINK-MS20233010>//
+#endif
+//><ADLINK-MS20240403>//
   endform;
 
 endformset;

--- a/Silicon/Ampere/AmpereAltraPkg/Drivers/PcieInitPei/RootComplexNVParam.c
+++ b/Silicon/Ampere/AmpereAltraPkg/Drivers/PcieInitPei/RootComplexNVParam.c
@@ -561,9 +561,10 @@ GetMaxSpeedGen (
     Controller = RootComplex->MaxPcieController;
   }
   for (Idx = 0; Idx < Controller; Idx++) {
-//><ADLINK-MS20232710>//
+//><ADLINK-MS20240604>//
 	MaxGen [Idx] = RootComplex->Pcie[Idx].MaxGen;  
     RootComplex->Pcie[Idx].MaxGen = RootComplex->Pcie[Idx].Active ? RootComplex->Pcie[Idx].MaxGen : LINK_SPEED_GEN3;
+	RootComplex->Pcie[Idx].DefaultMaxGen = LINK_SPEED_GEN3;
 //><ADLINK-MS20232710>//
   }
 
@@ -572,15 +573,17 @@ GetMaxSpeedGen (
     for (Idx = MaxPcieControllerOfRootComplexA; Idx < MaxPcieController; Idx++) {
       MaxGen[Idx] = RootComplex->Pcie[Idx].MaxGen;
       RootComplex->Pcie[Idx].MaxGen = RootComplex->Pcie[Idx].Active ? RootComplex->Pcie[Idx].MaxGen : LINK_SPEED_GEN3;
+      RootComplex->Pcie[Idx].DefaultMaxGen = LINK_SPEED_GEN3;
     }
   }
   else
   {
   	for (Idx = MaxPcieControllerOfRootComplexA; Idx < MaxPcieController; Idx++) {
        	RootComplex->Pcie[Idx].MaxGen = LINK_SPEED_GEN3;
+        RootComplex->Pcie[Idx].DefaultMaxGen = LINK_SPEED_GEN3;
     }
   }
-//><ADLINK-MS20232710>//
+//><ADLINK-MS20240604>//
 }
 
 VOID

--- a/Silicon/Ampere/AmpereAltraPkg/Drivers/RootComplexConfigDxe/RootComplexConfigDxe.c
+++ b/Silicon/Ampere/AmpereAltraPkg/Drivers/RootComplexConfigDxe/RootComplexConfigDxe.c
@@ -486,7 +486,7 @@ DriverCallback (
     case 2:
       Value->u8 = PcieRCDevMapHighDefaultSetting ((QuestionId - 0x8002) / MAX_EDITABLE_ELEMENTS, PrivateData);
       break;
-//><ADLINK-MS20232710>//
+//><ADLINK-MS20240604>//
     case 3:
     case 4:
     case 5:
@@ -495,10 +495,10 @@ DriverCallback (
     case 8:
     case 9:
     case 10:
-      Value->u8 = PcieRCGetMaxGen((QuestionId - 0x8002)/MAX_EDITABLE_ELEMENTS, PrivateData, (QuestionId - 0x8002) % MAX_EDITABLE_ELEMENTS);
+      Value->u8 = PcieRCGetDefaultMaxGen((QuestionId - 0x8002)/MAX_EDITABLE_ELEMENTS, PrivateData, (QuestionId - 0x8002) % MAX_EDITABLE_CONTROLLER_ELEMENTS);
       break;
     }
-//><ADLINK-MS20232710>//
+//><ADLINK-MS20240604>//
     break;
 
   case EFI_BROWSER_ACTION_RETRIEVE:
@@ -562,6 +562,20 @@ PcieRCActiveDefaultSetting (
 
   return RootComplex->DefaultActive;
 }
+//><ADLINK-MS20240604>//
+UINT8
+PcieRCGetDefaultMaxGen (
+  IN UINTN			RCIndex,
+  IN SCREEN_PRIVATE_DATA	*PrivateData,
+  IN UINT8			PcieIndex
+  )
+{
+
+  AC01_ROOT_COMPLEX *RootComplex = GetRootComplex(RCIndex);
+
+  return RootComplex->Pcie[PcieIndex].DefaultMaxGen;
+}
+//><ADLINK-MS20240604>//
 //><ADLINK-MS20232710>//
 UINT8
 PcieRCGetMaxGen (

--- a/Silicon/Ampere/AmpereAltraPkg/Drivers/RootComplexConfigDxe/RootComplexConfigDxe.h
+++ b/Silicon/Ampere/AmpereAltraPkg/Drivers/RootComplexConfigDxe/RootComplexConfigDxe.h
@@ -24,9 +24,10 @@ extern UINT8 RootComplexConfigVfrBin[];
 // create a packagelist (which contains Form packages, String packages, etc).
 //
 extern UINT8 RootComplexConfigDxeStrings[];
-//><ADLINK-MS20232710>//
+//><ADLINK-MS20240604>//
 #define MAX_EDITABLE_ELEMENTS 11
-//><ADLINK-MS20232710>//
+#define MAX_EDITABLE_CONTROLLER_ELEMENTS 8
+//><ADLINK-MS20240604>//
 #define RC0_STATUS_OFFSET  \
   OFFSET_OF (ROOT_COMPLEX_CONFIG_VARSTORE_DATA, RCStatus[0])
 #define RC0_BIFUR_LO_OFFSET  \
@@ -123,4 +124,12 @@ PcieRCGetMaxGen (
   IN UINT8                    PcieIndex
   );
 //><ADLINK-MS20232710>//
+//><ADLINK-MS20240604>//
+UINT8
+PcieRCGetDefaultMaxGen (
+  IN UINTN			RCIndex,
+  IN SCREEN_PRIVATE_DATA	*PrivateData,
+  IN UINT8			PcieIndex
+  );
+//><ADLINK-MS20240604>//
 #endif /* BOARD_PCIE_SCREEN_H_ */

--- a/Silicon/Ampere/AmpereAltraPkg/Include/Guid/RootComplexInfoHob.h
+++ b/Silicon/Ampere/AmpereAltraPkg/Include/Guid/RootComplexInfoHob.h
@@ -102,6 +102,7 @@ typedef enum {
 //
 // Data structure to store the PCIe controller information
 //
+//><ADLINK-MS20240604>//
 typedef struct {
   PHYSICAL_ADDRESS  CsrBase;               // Base address of CSR block
   PHYSICAL_ADDRESS  SnpsRamBase;           // Base address of Synopsys SRAM
@@ -111,10 +112,12 @@ typedef struct {
   UINT8             CurWidth;              // Current lanes x2/x4/x8/x16
   UINT8             ID;                    // ID of the controller within Root Complex
   UINT8             DevNum;                // Device number as part of Bus:Dev:Func
+  UINT8             DefaultMaxGen;
   BOOLEAN           Active;                // Active? Used in bi-furcation mode
   BOOLEAN           LinkUp;                // PHY and PCIE linkup
   BOOLEAN           HotPlug;               // Hotplug support
 } AC01_PCIE_CONTROLLER;
+//><ADLINK-MS20240604>//
 
 //
 // Data structure to store the Root Complex information


### PR DESCRIPTION
Commits to be merged:

1. Added MMC command to send shutdown signal.
2. Changed GUID of IMAGE_TYPE_ID_GUID.
3. Changed the PcdSerialRegisterBase value.
4. Removed the CPM feature.
5. Fix the PCIe load default in setup page to load Gen3.
6. Updated PCD variables for SMBIOS Type 0,1,2.